### PR TITLE
Fix Title Issue

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -85,3 +85,6 @@ compress_html:
   startings: []
   blanklines: false
   profile: false
+
+plugins:
+  - jekyll-seo-tag


### PR DESCRIPTION
Currently, this theme will render two `<title>` elements. You'll see this if you view the source of https://kevinl.info/just-the-class/. It contains `<title>Home - Just the Class</title>` and `<title>Home | Just the Class</title>`.

This problem is fixed when you add `jekyll-seo-tag`. `just-the-docs` uses this plugin. See [here](https://github.com/pmarsceill/just-the-docs/blob/54c921cbcdedd990e3338ee3558bcd17ee8e4691/_config.yml#L100).