### PR TITLE
Update staffer photo URL

### DIFF
--- a/_layouts/staffer.html
+++ b/_layouts/staffer.html
@@ -1,6 +1,6 @@
 <div class="staffer">
   {% if page.photo %}
-  <img class="staffer-image" src="{{ page.photo }}" alt="">
+  <img class="staffer-image" src="{{ site.baseurl }}{{ page.photo }}" alt="">
   {% endif %}
   <div>
     <h3 class="staffer-name">


### PR DESCRIPTION
To correctly display staff images on the page, need to include ``{{ site.baseurl }}`` in the ``_layouts/staffer.html`` template.