### PR TITLE
Fixed YAML valid date error

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -19,7 +19,7 @@ description: A modern, highly customizable, responsive Jekyll template for cours
 author: Kevin Lin
 baseurl: '/just-the-class' # the subpath of your site, e.g. /blog
 url: 'https://kevinl.info' # the base hostname & protocol for your site, e.g. http://example.com
-exclude: ["Gemfile", "Gemfile.lock", "LICENSE"]
+exclude: ["Gemfile", "Gemfile.lock", "LICENSE", vendor]
 
 # Theme settings
 remote_theme: just-the-docs/just-the-docs@v0.7.0


### PR DESCRIPTION
There is an error that is thrown when trying to host this template using GitHub pages, and I fixed it by adding `vendor` to the exclude list in the _config.yml. Here are [more details](https://github.com/jekyll/jekyll/issues/2938#issuecomment-56237068) on the error I got. Just a small fix, but hope it helps!